### PR TITLE
feat: add skeleton loading and clear search functionality

### DIFF
--- a/app/src/main/java/com/gabedev/mangako/MainActivity.kt
+++ b/app/src/main/java/com/gabedev/mangako/MainActivity.kt
@@ -228,7 +228,8 @@ fun MainAppNavHost(
                         }
                     },
                     searchQuery = collectionSearchQuery,
-                    onSearchOnExplore = { query ->
+                    onExploreSearch = { query ->
+                        collectionSearchQuery = ""
                         exploreSearchQuery = query
                         navController.navigate(Screen.Explore.route) {
                             popUpTo(navController.graph.startDestinationId) {

--- a/app/src/main/java/com/gabedev/mangako/ui/components/DynamicTopBar.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/components/DynamicTopBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -106,6 +107,23 @@ fun DynamicTopBar(
                                     contentDescription = stringResource(R.string.cd_search_icon),
                                     tint = MaterialTheme.colorScheme.onSurface
                                 )
+                            }
+                        },
+                        trailingIcon = {
+                            if (searchQuery.isNotEmpty()) {
+                                IconButton(onClick = {
+                                    searchQuery = ""
+                                    debouncedQuery = ""
+                                    if (!alwaysShowSearchBar) {
+                                        searchBarVisible = false
+                                    }
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.cd_close_search),
+                                        tint = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
                             }
                         },
                         placeholder = { Text(stringResource(placeholderRes)) }

--- a/app/src/main/java/com/gabedev/mangako/ui/components/SkeletonSearchItem.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/components/SkeletonSearchItem.kt
@@ -1,0 +1,138 @@
+package com.gabedev.mangako.ui.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+fun shimmerGradientColors(
+    baseColor: Color,
+    highlightColor: Color,
+    progress: Float
+): List<Pair<Float, Color>> {
+    val offset = progress * 2f
+    return listOf(
+        (0f + offset).coerceIn(0f, 1f) to baseColor,
+        (0.3f + offset).coerceIn(0f, 1f) to highlightColor,
+        (0.6f + offset).coerceIn(0f, 1f) to baseColor,
+    )
+}
+
+@Composable
+fun shimmerBrush(): Brush {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val progress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1200),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmerProgress",
+    )
+
+    val baseColor = MaterialTheme.colorScheme.surfaceVariant
+    val highlightColor = MaterialTheme.colorScheme.surface
+
+    val colorStops = shimmerGradientColors(baseColor, highlightColor, progress)
+
+    return Brush.linearGradient(
+        colorStops = colorStops.toTypedArray(),
+        start = Offset.Zero,
+        end = Offset(1000f, 0f),
+    )
+}
+
+@Composable
+fun SkeletonSearchItem() {
+    val brush = shimmerBrush()
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(0.2f),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.23f)
+                    .heightIn(128.dp)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(brush),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = 12.dp),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                // Title placeholder
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.6f)
+                        .height(16.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(brush),
+                )
+                // Author placeholder
+                Box(
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .fillMaxWidth(0.4f)
+                        .height(12.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(brush),
+                )
+                // Type badge placeholder
+                Box(
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .fillMaxWidth(0.25f)
+                        .height(12.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(brush),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SkeletonSearchList(count: Int = 3) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        repeat(count) {
+            SkeletonSearchItem()
+        }
+    }
+}

--- a/app/src/main/java/com/gabedev/mangako/ui/components/SkeletonSearchItem.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/components/SkeletonSearchItem.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -67,13 +67,12 @@ fun shimmerBrush(): Brush {
 }
 
 @Composable
-fun SkeletonSearchItem() {
+fun SkeletonSearchItem(modifier: Modifier = Modifier) {
     val brush = shimmerBrush()
 
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight(0.2f),
+        modifier = modifier
+            .fillMaxWidth(),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -83,7 +82,6 @@ fun SkeletonSearchItem() {
             Box(
                 modifier = Modifier
                     .fillMaxWidth(0.23f)
-                    .heightIn(128.dp)
                     .fillMaxHeight()
                     .clip(RoundedCornerShape(8.dp))
                     .background(brush),
@@ -126,13 +124,15 @@ fun SkeletonSearchItem() {
 }
 
 @Composable
-fun SkeletonSearchList(count: Int = 3) {
+fun SkeletonSearchList(count: Int = 5) {
     Column(
-        modifier = Modifier.padding(16.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         repeat(count) {
-            SkeletonSearchItem()
+            SkeletonSearchItem(modifier = Modifier.weight(1f))
         }
     }
 }

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/collection/MangaCollection.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/collection/MangaCollection.kt
@@ -57,7 +57,7 @@ fun MangaCollection(
     onMangaClick: (Manga) -> Unit,
     searchQuery: String,
     modifier: Modifier = Modifier,
-    onSearchOnExplore: (String) -> Unit = {}
+    onExploreSearch: (String) -> Unit = {}
 ) {
     val viewModel: MangaCollectionViewModel = viewModel(
         factory = MangaCollectionViewModelFactory(repository)
@@ -145,7 +145,10 @@ fun MangaCollection(
                             )
                             if (searchQuery.isNotBlank()) {
                                 TextButton(
-                                    onClick = { onSearchOnExplore(searchQuery) }
+                                    onClick = {
+                                        viewModel.clearSearchQuery()
+                                        onExploreSearch(searchQuery)
+                                    }
                                 ) {
                                     Text(
                                         text = stringResource(R.string.search_on_explore, searchQuery),

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/collection/MangaCollectionViewModel.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/collection/MangaCollectionViewModel.kt
@@ -100,6 +100,11 @@ class MangaCollectionViewModel (
         applyFilters()
     }
 
+    fun clearSearchQuery() {
+        _searchQuery.value = ""
+        applyFilters()
+    }
+
     fun toggleIncompleteFilter() {
         _showIncompleteOnly.value = !_showIncompleteOnly.value
         applyFilters()

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
@@ -13,9 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.CircularWavyProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
@@ -27,8 +27,8 @@ import com.gabedev.mangako.data.model.Manga
 import com.gabedev.mangako.data.repository.MangaDexRepository
 import com.gabedev.mangako.ui.components.CustomLoadingIndicator
 import com.gabedev.mangako.ui.components.MangaSearchItem
+import com.gabedev.mangako.ui.components.SkeletonSearchList
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MangaSearchScreen(
     modifier: Modifier = Modifier,
@@ -75,12 +75,7 @@ fun MangaSearchScreen(
             verticalArrangement = Arrangement.Center,
         ) {
             if (isLoading && mangaList.isEmpty()) {
-                CircularWavyProgressIndicator(
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(top = 32.dp),
-                )
+                SkeletonSearchList()
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/search_list/MangaSearchList.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -71,9 +72,7 @@ fun MangaSearchScreen(
             .fillMaxHeight()
             .fillMaxWidth(),
     ) {
-        Column(
-            verticalArrangement = Arrangement.Center,
-        ) {
+        Column {
             if (isLoading && mangaList.isEmpty()) {
                 SkeletonSearchList()
             } else {

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -56,6 +56,7 @@
     <string name="cd_search_icon">Ícone de busca</string>
     <string name="cd_back">Voltar</string>
     <string name="cd_search">Buscar</string>
+    <string name="cd_close_search">Limpar busca</string>
 
     <!-- Filters -->
     <string name="filter_incomplete">Incompletos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="cd_search_icon">Search Icon</string>
     <string name="cd_back">Back</string>
     <string name="cd_search">Search</string>
+    <string name="cd_close_search">Clear search</string>
 
     <!-- Filters -->
     <string name="filter_incomplete">Incomplete</string>

--- a/app/src/test/java/com/gabedev/mangako/data/model/MangaWithOwnedTest.kt
+++ b/app/src/test/java/com/gabedev/mangako/data/model/MangaWithOwnedTest.kt
@@ -2,6 +2,7 @@ package com.gabedev.mangako.data.model
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -85,12 +86,10 @@ class MangaWithOwnedTest {
 
     @Test
     fun `toManga does not include volumeOwned`() {
-        val mwo = createMangaWithOwned()
-        val manga = mwo.toManga()
+        val manga = createMangaWithOwned().toManga()
 
-        // Manga data class does not have volumeOwned field
-        // We verify it's a Manga instance with the correct type
-        assertTrue(manga is Manga)
+        val mangaFields = manga::class.java.declaredFields.map { it.name }
+        assertFalse("Manga should not have volumeOwned field", mangaFields.contains("volumeOwned"))
     }
 
     @Test
@@ -135,5 +134,40 @@ class MangaWithOwnedTest {
         val mwo2 = createMangaWithOwned()
 
         assertEquals(mwo1, mwo2)
+    }
+
+    @Test
+    fun `MangaWithOwned inequality when field differs`() {
+        val mwo1 = createMangaWithOwned()
+        val mwo2 = mwo1.copy(volumeOwned = 99)
+
+        assertNotEquals(mwo1, mwo2)
+    }
+
+    @Test
+    fun `toManga handles edge case values`() {
+        val mwo = MangaWithOwned(
+            id = "",
+            title = "",
+            altTitle = null,
+            type = null,
+            coverId = null,
+            coverFileName = null,
+            coverUrl = "",
+            authorId = null,
+            author = null,
+            description = "",
+            status = null,
+            volumeCount = 0,
+            isOnUserLibrary = false,
+            volumeOwned = 0
+        )
+        val manga = mwo.toManga()
+
+        assertEquals("", manga.id)
+        assertEquals("", manga.title)
+        assertEquals("", manga.coverUrl)
+        assertEquals("", manga.description)
+        assertEquals(0, manga.volumeCount)
     }
 }

--- a/app/src/test/java/com/gabedev/mangako/ui/components/SkeletonSearchItemTest.kt
+++ b/app/src/test/java/com/gabedev/mangako/ui/components/SkeletonSearchItemTest.kt
@@ -1,0 +1,69 @@
+package com.gabedev.mangako.ui.components
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SkeletonSearchItemTest {
+
+    private val baseColor = Color.Gray
+    private val highlightColor = Color.White
+
+    @Test
+    fun `shimmerGradientColors at progress 0 starts with base color`() {
+        val colors = shimmerGradientColors(baseColor, highlightColor, 0f)
+
+        assertEquals(3, colors.size)
+        assertEquals(baseColor, colors[0].second)
+        assertEquals(highlightColor, colors[1].second)
+        assertEquals(baseColor, colors[2].second)
+        assertEquals(0f, colors[0].first)
+        assertEquals(0.3f, colors[1].first)
+        assertEquals(0.6f, colors[2].first)
+    }
+
+    @Test
+    fun `shimmerGradientColors at progress 0_5 shifts offsets`() {
+        val colors = shimmerGradientColors(baseColor, highlightColor, 0.5f)
+
+        assertEquals(3, colors.size)
+        assertEquals(baseColor, colors[0].second)
+        assertEquals(highlightColor, colors[1].second)
+        assertEquals(baseColor, colors[2].second)
+        assertEquals(1f, colors[0].first)
+        assertEquals(1f, colors[1].first, 0.01f)
+        assertEquals(1f, colors[2].first, 0.01f)
+    }
+
+    @Test
+    fun `shimmerGradientColors at progress 1 clamps offsets to 1`() {
+        val colors = shimmerGradientColors(baseColor, highlightColor, 1f)
+
+        assertEquals(3, colors.size)
+        colors.forEach { (offset, _) ->
+            assert(offset in 0f..1f) { "Offset $offset is out of [0, 1] range" }
+        }
+    }
+
+    @Test
+    fun `shimmerGradientColors preserves color order at all progress values`() {
+        listOf(0f, 0.25f, 0.5f, 0.75f, 1f).forEach { progress ->
+            val colors = shimmerGradientColors(baseColor, highlightColor, progress)
+            assertEquals(baseColor, colors[0].second)
+            assertEquals(highlightColor, colors[1].second)
+            assertEquals(baseColor, colors[2].second)
+        }
+    }
+
+    @Test
+    fun `shimmerGradientColors offsets are monotonically non-decreasing`() {
+        listOf(0f, 0.1f, 0.3f, 0.5f, 0.8f, 1f).forEach { progress ->
+            val colors = shimmerGradientColors(baseColor, highlightColor, progress)
+            for (i in 0 until colors.size - 1) {
+                assert(colors[i].first <= colors[i + 1].first) {
+                    "At progress=$progress, offset ${colors[i].first} > ${colors[i + 1].first}"
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/gabedev/mangako/ui/screens/collection/MangaCollectionViewModelTest.kt
+++ b/app/src/test/java/com/gabedev/mangako/ui/screens/collection/MangaCollectionViewModelTest.kt
@@ -548,4 +548,39 @@ class MangaCollectionViewModelTest {
         assertFalse(viewModel!!.isMultiSelectActive.value)
         assertTrue(viewModel!!.selectedIds.value.isEmpty())
     }
+
+    // clearSearchQuery tests
+    @Test
+    fun `clearSearchQuery resets query to empty string`() = runTest(testDispatcher) {
+        coEvery { repository.getMangaOnLibrary() } returns emptyList()
+        coEvery { repository.getMangaIdsWithSpecialEditions() } returns emptyList()
+
+        viewModel = MangaCollectionViewModel(repository, testDispatcher)
+        advanceUntilIdle()
+
+        viewModel!!.setSearchQuery("One Piece")
+        assertEquals("One Piece", viewModel!!.searchQuery.value)
+
+        viewModel!!.clearSearchQuery()
+        assertEquals("", viewModel!!.searchQuery.value)
+    }
+
+    @Test
+    fun `clearSearchQuery after filtering shows all manga`() = runTest(testDispatcher) {
+        val manga1 = createMangaWithOwned(id = "1", title = "One Piece")
+        val manga2 = createMangaWithOwned(id = "2", title = "Naruto")
+        val manga3 = createMangaWithOwned(id = "3", title = "Bleach")
+
+        coEvery { repository.getMangaOnLibrary() } returns listOf(manga1, manga2, manga3)
+        coEvery { repository.getMangaIdsWithSpecialEditions() } returns emptyList()
+
+        viewModel = MangaCollectionViewModel(repository, testDispatcher)
+        advanceUntilIdle()
+
+        viewModel!!.setSearchQuery("One")
+        assertEquals(1, viewModel!!.mangaCollection.value.size)
+
+        viewModel!!.clearSearchQuery()
+        assertEquals(3, viewModel!!.mangaCollection.value.size)
+    }
 }


### PR DESCRIPTION
## Summary
- **Skeleton loading**: Add `SkeletonSearchItem` and `SkeletonSearchList` composables with shimmer animation, replacing the circular loading indicator in the explore/search screen for a smoother UX
- **Clear search**: Add clear search functionality in MangaCollection with a dedicated button in DynamicTopBar
- **Tests**: Add unit tests for skeleton components, MangaWithOwned model, and collection view model clear search

## Test plan
- [x] Open explore screen and trigger a search — verify skeleton placeholders appear with shimmer animation
- [x] Verify search results replace skeletons once loaded
- [x] In collection screen, search for something, then tap the clear button — verify query resets
- [x] Run `./gradlew :app:testDebugUnitTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)