### PR TITLE
feat: add Not Owned filter to volume list

### DIFF
--- a/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
@@ -87,7 +87,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-fun filterVolumes(
+internal fun filterVolumes(
     volumes: List<Volume>,
     showSpecialEditions: Boolean,
     showNotOwnedOnly: Boolean

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
@@ -74,6 +74,7 @@ import com.gabedev.mangako.core.Utils
 import com.gabedev.mangako.data.local.getConfigText
 import com.gabedev.mangako.data.local.saveConfigText
 import com.gabedev.mangako.data.model.Manga
+import com.gabedev.mangako.data.model.Volume
 import com.gabedev.mangako.data.repository.LibraryRepository
 import com.gabedev.mangako.data.repository.MangaDexRepository
 import com.gabedev.mangako.ui.components.ConfirmDialog
@@ -86,6 +87,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+fun filterVolumes(
+    volumes: List<Volume>,
+    showSpecialEditions: Boolean,
+    showNotOwnedOnly: Boolean
+): List<Volume> {
+    var result = volumes
+    if (!showSpecialEditions) result = result.filter { !it.isSpecialEdition }
+    if (showNotOwnedOnly) result = result.filter { !it.owned }
+    return result
+}
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun MangaDetail(
@@ -96,6 +108,7 @@ fun MangaDetail(
     modifier: Modifier = Modifier
 ) {
     var specialCoverFilter by remember { mutableStateOf(false) }
+    var notOwnedFilter by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val viewModeFlow = remember { context.getConfigText() }
     val viewMode by viewModeFlow.collectAsState(initial = "list")
@@ -105,14 +118,8 @@ fun MangaDetail(
     )
     val mangaState by viewModel.mangaState.collectAsState()
     val volumeList by viewModel.volumeList.collectAsState()
-    val filteredVolumeList by remember(specialCoverFilter, volumeList) {
-        mutableStateOf(
-            if (specialCoverFilter) {
-                volumeList
-            } else {
-                volumeList.filter { !it.isSpecialEdition }
-            }
-        )
+    val filteredVolumeList by remember(specialCoverFilter, notOwnedFilter, volumeList) {
+        mutableStateOf(filterVolumes(volumeList, specialCoverFilter, notOwnedFilter))
     }
     val isCoverLoading by viewModel.isVolumeLoading.collectAsState()
     val canLoadMore by viewModel.noMoreVolume.collectAsState()
@@ -362,24 +369,44 @@ fun MangaDetail(
                     }
                 }
                 item(span = { GridItemSpan(maxLineSpan) }) {
-                    FilterChip(
-                        onClick = { specialCoverFilter = !specialCoverFilter },
-                        label = {
-                            Text(stringResource(R.string.label_special_editions))
-                        },
-                        selected = specialCoverFilter,
-                        leadingIcon = if (specialCoverFilter) {
-                            {
-                                Icon(
-                                    imageVector = Icons.Filled.Done,
-                                    contentDescription = stringResource(R.string.cd_done_icon),
-                                    modifier = Modifier.size(FilterChipDefaults.IconSize)
-                                )
-                            }
-                        } else {
-                            null
-                        },
-                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        FilterChip(
+                            onClick = { specialCoverFilter = !specialCoverFilter },
+                            label = {
+                                Text(stringResource(R.string.label_special_editions))
+                            },
+                            selected = specialCoverFilter,
+                            leadingIcon = if (specialCoverFilter) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Done,
+                                        contentDescription = stringResource(R.string.cd_done_icon),
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                        )
+                        FilterChip(
+                            onClick = { notOwnedFilter = !notOwnedFilter },
+                            label = {
+                                Text(stringResource(R.string.label_not_owned))
+                            },
+                            selected = notOwnedFilter,
+                            leadingIcon = if (notOwnedFilter) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Done,
+                                        contentDescription = stringResource(R.string.cd_done_icon),
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                        )
+                    }
                 }
                 item(span = { GridItemSpan(maxLineSpan) }) {
                     Row(

--- a/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
+++ b/app/src/main/java/com/gabedev/mangako/ui/screens/detail/MangaDetail.kt
@@ -118,8 +118,8 @@ fun MangaDetail(
     )
     val mangaState by viewModel.mangaState.collectAsState()
     val volumeList by viewModel.volumeList.collectAsState()
-    val filteredVolumeList by remember(specialCoverFilter, notOwnedFilter, volumeList) {
-        mutableStateOf(filterVolumes(volumeList, specialCoverFilter, notOwnedFilter))
+    val filteredVolumeList = remember(specialCoverFilter, notOwnedFilter, volumeList) {
+        filterVolumes(volumeList, specialCoverFilter, notOwnedFilter)
     }
     val isCoverLoading by viewModel.isVolumeLoading.collectAsState()
     val canLoadMore by viewModel.noMoreVolume.collectAsState()

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -27,6 +27,7 @@
 
     <!-- Detail Screen - Labels -->
     <string name="label_special_editions">Edições Especiais</string>
+    <string name="label_not_owned">Não Adquiridos</string>
     <string name="label_volumes">Volumes</string>
     <string name="label_no_volumes_found">Nenhum volume encontrado.</string>
     <string name="label_loading_covers">Carregando capas…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
 
     <!-- Detail Screen - Labels -->
     <string name="label_special_editions">Special Editions</string>
+    <string name="label_not_owned">Not Owned</string>
     <string name="label_volumes">Volumes</string>
     <string name="label_no_volumes_found">No volumes found.</string>
     <string name="label_loading_covers">Loading covers…</string>

--- a/app/src/test/java/com/gabedev/mangako/ui/screens/detail/FilterVolumesTest.kt
+++ b/app/src/test/java/com/gabedev/mangako/ui/screens/detail/FilterVolumesTest.kt
@@ -1,0 +1,93 @@
+package com.gabedev.mangako.ui.screens.detail
+
+import com.gabedev.mangako.data.model.Volume
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FilterVolumesTest {
+
+    private fun volume(
+        id: String,
+        owned: Boolean = false,
+        isSpecialEdition: Boolean = false
+    ) = Volume(
+        id = id,
+        mangaId = "manga-1",
+        title = "Title",
+        coverUrl = "url",
+        volume = 1f,
+        locale = "en",
+        owned = owned,
+        isSpecialEdition = isSpecialEdition
+    )
+
+    @Test
+    fun `no filters returns all non-special volumes`() {
+        val volumes = listOf(
+            volume("1", owned = true),
+            volume("2", owned = false),
+            volume("3", owned = true, isSpecialEdition = true)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = false, showNotOwnedOnly = false)
+        assertEquals(listOf(volumes[0], volumes[1]), result)
+    }
+
+    @Test
+    fun `not owned only filter returns unowned non-special volumes`() {
+        val volumes = listOf(
+            volume("1", owned = true),
+            volume("2", owned = false),
+            volume("3", owned = false, isSpecialEdition = true)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = false, showNotOwnedOnly = true)
+        assertEquals(listOf(volumes[1]), result)
+    }
+
+    @Test
+    fun `both filters active returns all unowned volumes including special`() {
+        val volumes = listOf(
+            volume("1", owned = true),
+            volume("2", owned = false),
+            volume("3", owned = false, isSpecialEdition = true)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = true, showNotOwnedOnly = true)
+        assertEquals(listOf(volumes[1], volumes[2]), result)
+    }
+
+    @Test
+    fun `special editions filter shows special and not-owned filters compose`() {
+        val volumes = listOf(
+            volume("1", owned = true, isSpecialEdition = true),
+            volume("2", owned = false, isSpecialEdition = true),
+            volume("3", owned = false)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = true, showNotOwnedOnly = true)
+        assertEquals(listOf(volumes[1], volumes[2]), result)
+    }
+
+    @Test
+    fun `special editions only returns all volumes`() {
+        val volumes = listOf(
+            volume("1", owned = true),
+            volume("2", owned = false, isSpecialEdition = true)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = true, showNotOwnedOnly = false)
+        assertEquals(volumes, result)
+    }
+
+    @Test
+    fun `empty list returns empty list`() {
+        val result = filterVolumes(emptyList(), showSpecialEditions = true, showNotOwnedOnly = true)
+        assertEquals(emptyList<Volume>(), result)
+    }
+
+    @Test
+    fun `all owned with not-owned filter returns empty`() {
+        val volumes = listOf(
+            volume("1", owned = true),
+            volume("2", owned = true)
+        )
+        val result = filterVolumes(volumes, showSpecialEditions = false, showNotOwnedOnly = true)
+        assertEquals(emptyList<Volume>(), result)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract volume filtering logic into a reusable `filterVolumes` function
- Add a "Not Owned" filter chip next to the existing "Special Editions" filter in MangaDetail
- Add localized strings for the new filter (EN and PT)
- Add unit tests for the filtering logic

## Test plan
- [x] Open a manga detail screen and verify both filter chips appear
- [x] Toggle "Not Owned" and confirm only unowned volumes are shown
- [x] Toggle "Special Editions" and confirm special edition volumes appear/disappear
- [x] Combine both filters and verify they work together correctly
- [x] Run `./gradlew :app:testDebugUnitTest --tests "com.gabedev.mangako.ui.screens.detail.FilterVolumesTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)